### PR TITLE
Handled complex types

### DIFF
--- a/examples/base/base.go
+++ b/examples/base/base.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/kristoiv/gocqltable"
+	"github.com/NexwayGroup/gocqltable"
 	"github.com/gocql/gocql"
 )
 

--- a/examples/crud/crud.go
+++ b/examples/crud/crud.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/kristoiv/gocqltable"
-	"github.com/kristoiv/gocqltable/recipes"
+	"github.com/NexwayGroup/gocqltable"
+	"github.com/NexwayGroup/gocqltable/recipes"
 	"github.com/gocql/gocql"
 )
 

--- a/query.go
+++ b/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gocql/gocql"
 
-	r "github.com/kristoiv/gocqltable/reflect"
+	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
 )
 
 type Query struct {

--- a/query.go
+++ b/query.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gocql/gocql"
 
-	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
+	r "github.com/NexwayGroup/gocqltable/reflect"
 )
 
 type Query struct {

--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -9,9 +9,8 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/kristoiv/gocqltable"
-
-	r "github.com/kristoiv/gocqltable/reflect"
+	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
+	"github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable"
 )
 
 type RangeInterface interface {
@@ -71,7 +70,11 @@ func (t CRUD) insert(row interface{}, ttl *time.Time) error {
 		// Append to insertion slices
 		fields = append(fields, strings.ToLower(fmt.Sprintf("%q", key)))
 		placeholders = append(placeholders, "?")
-		vals = append(vals, value)
+		converted, err := gocqltable.ProcessValue(value)
+		if err != nil {
+			return errors.New(fmt.Sprintf("Inserting row failed due to un marshallable value for key %q", key))
+		}
+		vals = append(vals, converted)
 	}
 
 	options := ""

--- a/recipes/crud.go
+++ b/recipes/crud.go
@@ -9,8 +9,8 @@ import (
 	"reflect"
 	"time"
 
-	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
-	"github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable"
+	r "github.com/NexwayGroup/gocqltable/reflect"
+	"github.com/NexwayGroup/gocqltable"
 )
 
 type RangeInterface interface {

--- a/reflect/reflect.go
+++ b/reflect/reflect.go
@@ -55,7 +55,7 @@ func MapToStruct(m map[string]interface{}, struc interface{}) error {
 			//fmt.Printf("type struct: %q, %q, %q\n", structField.Type(), structField.Type().Name(), structField.Kind())
 			//fmt.Printf("type value: %q\n", r.TypeOf(v).Name())
 			//fmt.Printf("value: %+v\n", r.ValueOf(v))
-			if structField.Kind().String() == "slice" || r.TypeOf(v).Kind().String() == "slice" {
+			if structField.Kind().String() == "slice" && r.TypeOf(v).Kind().String() == "slice" {
 				if structField.Type().Elem() == r.TypeOf(v).Elem() {
 					//fmt.Print("Slices of same type\n")
 					structField.Set(r.ValueOf(v))
@@ -84,7 +84,7 @@ func MapToStruct(m map[string]interface{}, struc interface{}) error {
 					structField.Set(result)
 				}
 			} else if structField.Type().Name() == "" || r.TypeOf(v).Name() == "" {
-				fmt.Printf("WTF are these types???!!! %q %q\n", structField.Kind().String(), r.TypeOf(v).Kind().String())
+				return fmt.Errorf("WTF are these types???!!! %q %q\n", structField.Kind().String(), r.TypeOf(v).Kind().String())
 			} else if structField.Type().Name() == r.TypeOf(v).Name() {
 				//fmt.Print("Field set naturally!!!\n")
 				structField.Set(r.ValueOf(v))
@@ -92,7 +92,7 @@ func MapToStruct(m map[string]interface{}, struc interface{}) error {
 				//fmt.Print("Field set with convert !!!\n")
 				structField.Set(r.ValueOf(v).Convert(structField.Type()))
 			} else {
-				fmt.Print("Please handle these types !!!\n")
+				return fmt.Errorf("Please handle these types: %s with %s\n", structField.Kind().String(), r.TypeOf(v).Kind().String())
 			}
 		} else {
 			//fmt.Printf("field %q not found\n", k) TODO: in which situation do we reach this point? oO

--- a/table.go
+++ b/table.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gocql/gocql"
 
-	r "github.com/kristoiv/gocqltable/reflect"
+	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
 )
 
 type TableInterface interface {

--- a/table.go
+++ b/table.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/gocql/gocql"
 
-	r "github.com/NexwayGroup/nx-dmp-enduser-unifier/cassandra/gocqltable/reflect"
+	r "github.com/NexwayGroup/gocqltable/reflect"
 )
 
 type TableInterface interface {

--- a/type.go
+++ b/type.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
+	"encoding/json"
 )
 
 type Counter int
@@ -20,7 +21,8 @@ func stringTypeOf(i interface{}) (string, error) {
 			elemVal := reflect.Indirect(reflect.New(reflect.TypeOf(i).Elem())).Interface()
 			ct := cassaType(elemVal)
 			if ct == gocql.TypeCustom {
-				return "", fmt.Errorf("Unsupported type %T", i)
+				ct = gocql.TypeVarchar
+				//return "", fmt.Errorf("Unsupported type %T", i)
 			}
 			return fmt.Sprintf("list<%v>", ct), nil
 		case reflect.Map:
@@ -36,9 +38,58 @@ func stringTypeOf(i interface{}) (string, error) {
 	}
 	ct := cassaType(i)
 	if ct == gocql.TypeCustom {
-		return "", fmt.Errorf("Unsupported type %T", i)
+		ct = gocql.TypeVarchar
+		// return "", fmt.Errorf("Unsupported type %T", i)
 	}
 	return cassaTypeToString(ct)
+}
+
+type structure struct {
+	A string
+        B int
+}
+
+func ProcessValue(i interface{}) (interface{}, error) {
+	if i == nil {
+		return nil, nil
+	}
+	_, isByteSlice := i.([]byte)
+	if !isByteSlice {
+		// Check if we found a higher kinded type
+		switch reflect.ValueOf(i).Kind() {
+		case reflect.Slice:
+			elemVal := reflect.Indirect(reflect.New(reflect.TypeOf(i).Elem())).Interface()
+			ct := cassaType(elemVal)
+			if ct == gocql.TypeCustom {
+				s := reflect.ValueOf(i)
+				result := make([]string, 0, s.Len())
+				for j := 0; j < s.Len(); j++ {
+					txt, err := json.Marshal(s.Index(j).Interface())
+					if err != nil {
+						return "", fmt.Errorf("Unsupported translation of value type %T", err)
+					}
+					result = append(result, string(txt))
+				}
+				return result, nil
+			}
+			return i, nil
+		case reflect.Map:
+			keyVal := reflect.Indirect(reflect.New(reflect.TypeOf(i).Key())).Interface()
+			elemVal := reflect.Indirect(reflect.New(reflect.TypeOf(i).Elem())).Interface()
+			keyCt := cassaType(keyVal)
+			elemCt := cassaType(elemVal)
+			if keyCt == gocql.TypeCustom || elemCt == gocql.TypeCustom {
+				return "", fmt.Errorf("Unsupported map key or value type %T", i)
+			}
+			return fmt.Sprintf("map<%v, %v>", keyCt, elemCt), nil
+		}
+	}
+	ct := cassaType(i)
+	if ct == gocql.TypeCustom {
+		res, err := json.Marshal(i)
+		return string(res), err
+	}
+	return i, nil
 }
 
 func cassaType(i interface{}) gocql.Type {
@@ -63,6 +114,20 @@ func cassaType(i interface{}) gocql.Type {
 		return gocql.TypeBlob
 	case Counter:
 		return gocql.TypeCounter
+	}
+	switch reflect.ValueOf(i).Kind() {
+	case reflect.Int, reflect.Int32:
+		return gocql.TypeInt
+	case reflect.Int64:
+		return gocql.TypeBigInt
+	case reflect.String:
+		return gocql.TypeVarchar
+	case reflect.Float32:
+		return gocql.TypeFloat
+	case reflect.Float64:
+		return gocql.TypeDouble
+	case reflect.Bool:
+		return gocql.TypeBoolean
 	}
 	return gocql.TypeCustom
 }


### PR DESCRIPTION
The code in this PR handle the complex types found inside the struct we store in the table.

The idea for now is just to store the complex types as json string (running a json.marshal on them) and to unmarshal them at retrieval.
It's the same for slices of complex types, we will store them as a list of string and rebuild the list on retrieval.